### PR TITLE
Add condition to handle empty input

### DIFF
--- a/cs2pr
+++ b/cs2pr
@@ -32,16 +32,18 @@ if ($argc === 1) {
 $exit = 0;
 $root = simplexml_load_string($xml);
 
-foreach($root as $file) {
-    $filename = (string)$file['name'];
+if($root) {
+    foreach($root as $file) {
+        $filename = (string)$file['name'];
 
-    foreach($file as $error) {
-        $type = (string) $error['severity'];
-        $line = (string) $error['line'];
-        $message = (string) $error['message'];
+        foreach($file as $error) {
+            $type = (string) $error['severity'];
+            $line = (string) $error['line'];
+            $message = (string) $error['message'];
 
-        annotateCheck(annotateType($type), relativePath($filename), $line, $message);
-        $exit = 1;
+            annotateCheck(annotateType($type), relativePath($filename), $line, $message);
+            $exit = 1;
+        }
     }
 }
 


### PR DESCRIPTION
This PR wraps the `foreach` loop in `cs2pr` script in an if condition to handle cases when `simplexml_load_string` will return false.

This will happen when 
- Input `xml` file is empty or it does not exist
- 2 or more arguments are passed to the script.

Ref: https://www.php.net/manual/en/function.simplexml-load-string.php

