### PR TITLE
Enhancement: Run friendsofphp/php-cs-fixer on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,39 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "Continuous Integration"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2.0.0"
+
+      - name: "Install PHP with extensions"
+        uses: "shivammathur/setup-php@1.8.1"
+        with:
+          coverage: "none"
+          extensions: "simplexml"
+          php-version: "7.0"
+
+      - name: "Cache dependencies installed with composer"
+        uses: "actions/cache@v1.0.3"
+        with:
+          path: "~/.composer/cache"
+          key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+
+      - name: "Install dependencies with composer"
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      - name: "Run friendsofphp/php-cs-fixer"
+        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --verbose"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+.php_cs.cache
+composer.lock

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+$header = <<<'EOF'
+Turns checkstyle based XML-Reports into Github Pull Request Annotations via the Checks API. This script is meant for use within your GithubAction.
+
+(c) Markus Staab <markus.staab@redaxo.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+https://github.com/staabm/annotate-pull-request-from-checkstyle
+EOF;
+
+$finder = PhpCsFixer\Finder::create()
+    ->files()
+    ->in(__DIR__)
+    ->name('cs2pr');
+
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules([
+        'header_comment' => [
+            'commentType' => 'comment',
+            'header' => $header,
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ]
+    ]);

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Annotate a Pull Request based on a Checkstyle XML-report
 
+[![Continuous Integration](https://github.com/staabm/annotate-pull-request-from-checkstyle/workflows/Continuous%20Integration/badge.svg)](https://github.com/staabm/annotate-pull-request-from-checkstyle/actions)
+
 Turns [checkstyle based XML-Reports](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/checkstyle.xsd) into Github Pull Request [Annotations via the Checks API](https://developer.github.com/v3/checks/).
 This script is meant for use within your GithubAction.
 
-That means you no longer search thru your GithubAction logfiles. 
+That means you no longer search thru your GithubAction logfiles.
 No need to interpret messages which are formatted differently with every tool.
 Instead you can focus on your Pull Request, and you don't need to leave the Pull Request area.
 
@@ -97,7 +99,7 @@ jobs:
                 vendor/bin/phpstan analyse --error-format=checkstyle | vendor/bin/cs2pr
 ```
 
-# Resources 
+# Resources
 
 [GithubAction Problem Matchers](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md)
 

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,16 @@
     "ext-simplexml" : "*"
   },
   "require-dev" : {
-    "phpunit/phpunit" : "^7.0"
+    "phpunit/phpunit" : "^7.0",
+    "friendsofphp/php-cs-fixer": "^2.16.1"
   },
   "authors" : [
     {
       "name" : "Markus Staab"
     }
   ],
-  "bin" : ["cs2pr"]
+  "bin" : ["cs2pr"],
+  "scripts": {
+    "cs": "php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose"
+  }
 }


### PR DESCRIPTION
This PR

* [x] runs `friendsofphp/php-cs-fixer` on GitHub Actions

💁 Checking out this branch and running

```
$ composer install && composer cs
```

should yield the following

```
> php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
Loaded config default from ".php_cs".
Using cache file ".php_cs.cache".
.
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error

Fixed all files in 0.017 seconds, 12.000 MB memory used
```