### PR TITLE
Fix: Remove phpunit/phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "ext-simplexml" : "*"
   },
   "require-dev" : {
-    "phpunit/phpunit" : "^7.0",
     "friendsofphp/php-cs-fixer": "^2.16.1"
   },
   "authors" : [


### PR DESCRIPTION
This PR

* [x] removes `phpunit/phpunit`

Follows #8.

💁‍♂ It's currently an unused dependency!