### PR TITLE
fix empty short root node

### DIFF
--- a/cs2pr
+++ b/cs2pr
@@ -31,7 +31,7 @@ if ($argc === 1) {
 
 $root = @simplexml_load_string($xml);
 
-if (!$root) {
+if ($root === false) {
     $errors = libxml_get_errors();
     if ($errors) {
         fwrite(STDERR, $errors[0]->message.' on line '.$errors[0]->line.', column '.$errors[0]->column);

--- a/tests/noerrors/only-header-php-cs-fixer.xml
+++ b/tests/noerrors/only-header-php-cs-fixer.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle/>

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -44,3 +44,4 @@ testXml(__DIR__.'/fail/multiple-suites.xml', 2);
 testXml(__DIR__.'/errors/minimal.xml', 1, file_get_contents(__DIR__.'/errors/minimal.expect'));
 
 testXml(__DIR__.'/noerrors/only-header.xml', 0, file_get_contents(__DIR__.'/noerrors/only-header.expect'));
+testXml(__DIR__.'/noerrors/only-header-php-cs-fixer.xml', 0, file_get_contents(__DIR__.'/noerrors/only-header-php-cs-fixer.expect'));


### PR DESCRIPTION
Fixes #15 

I don't know why the short root node behaves differently ... but the problem is that an empty array was returned from `simplexml_load_string()`.

See https://www.php.net/manual/en/function.simplexml-load-string.php:
<img width="1056" alt="Bildschirmfoto 2020-02-09 um 17 13 25" src="https://user-images.githubusercontent.com/533162/74105584-7da28280-4b5f-11ea-9f65-65bc01da42e7.png">
