### PR TITLE
add options gracefulWarnings and colorize

### DIFF
--- a/cs2pr
+++ b/cs2pr
@@ -18,14 +18,43 @@ gc_disable();
 
 $version = '1.0.6-dev';
 
-if ($argc === 1) {
+// options
+$colorize = false;
+$gracefulWarnings = false;
+
+// parameters
+$params = [];
+foreach ($argv as $arg) {
+    if (substr($arg, 0, 2) === '--') {
+        $option = substr($arg, 2);
+        switch ($option) {
+        case 'graceful-warnings':
+            $gracefulWarnings = true;
+            break;
+        case 'colorize':
+            $colorize = true;
+            break;
+        default:
+            echo "Unknown option ".$option."\n";
+            exit(9);
+        }
+    } else {
+        $params[] = $arg;
+    }
+}
+
+if (count($params) === 1) {
     $xml = stream_get_contents(STDIN);
-} elseif ($argc === 2 && file_exists($argv[1])) {
-    $xml = file_get_contents($argv[1]);
+} elseif (count($params) === 2 && file_exists($params[1])) {
+    $xml = file_get_contents($params[1]);
 } else {
     echo "cs2pr $version\n";
     echo "Annotate a Github Pull Request based on a Checkstyle XML-report.\n";
-    echo "Usage: ". $argv[0] ." <filename>\n";
+    echo "Usage: ". $params[0] ." [OPTION]... <filename>\n";
+    echo "\n";
+    echo "Option can be:\n";
+    echo "  --graceful-warnings   Don't exit with error codes if there are only warnings.\n";
+    echo "  --colorize            Colorize the output (still compatible with Github Annotations)\n";
     exit(9);
 }
 
@@ -58,8 +87,11 @@ foreach ($root as $file) {
         $line = (string) $error['line'];
         $message = (string) $error['message'];
 
-        annotateCheck(annotateType($type), relativePath($filename), $line, $message);
-        $exit = 1;
+        annotateCheck(annotateType($type), relativePath($filename), $line, $message, $colorize);
+
+        if (!$gracefulWarnings || $type === 'error') {
+            $exit = 1;
+        }
     }
 }
 
@@ -71,9 +103,15 @@ exit($exit);
  * @param int $line
  * @param string $message
  */
-function annotateCheck($type, $filename, $line, $message)
+function annotateCheck($type, $filename, $line, $message, $colorize=false)
 {
+    if ($colorize) {
+        echo "\033[".($type==='error' ? '91' : '93')."m\n";
+    }
     echo "::{$type} file={$filename},line={$line}::{$message}\n";
+    if ($colorize) {
+        echo "\033[0m";
+    }
 }
 
 function relativePath($path)

--- a/cs2pr
+++ b/cs2pr
@@ -52,7 +52,7 @@ if (count($params) === 1) {
     echo "Annotate a Github Pull Request based on a Checkstyle XML-report.\n";
     echo "Usage: ". $params[0] ." [OPTION]... <filename>\n";
     echo "\n";
-    echo "Option can be:\n";
+    echo "Supported options:\n";
     echo "  --graceful-warnings   Don't exit with error codes if there are only warnings.\n";
     echo "  --colorize            Colorize the output (still compatible with Github Annotations)\n";
     exit(9);
@@ -103,7 +103,7 @@ exit($exit);
  * @param int $line
  * @param string $message
  */
-function annotateCheck($type, $filename, $line, $message, $colorize=false)
+function annotateCheck($type, $filename, $line, $message, $colorize)
 {
     if ($colorize) {
         echo "\033[".($type==='error' ? '91' : '93')."m\n";

--- a/cs2pr
+++ b/cs2pr
@@ -87,9 +87,10 @@ foreach ($root as $file) {
         $line = (string) $error['line'];
         $message = (string) $error['message'];
 
-        annotateCheck(annotateType($type), relativePath($filename), $line, $message, $colorize);
+        $annotateType = annotateType($type);
+        annotateCheck($annotateType, relativePath($filename), $line, $message, $colorize);
 
-        if (!$gracefulWarnings || $type === 'error') {
+        if (!$gracefulWarnings || $annotateType === 'error') {
             $exit = 1;
         }
     }

--- a/cs2pr
+++ b/cs2pr
@@ -102,6 +102,7 @@ exit($exit);
  * @param string $filename
  * @param int $line
  * @param string $message
+ * @param boolean $colorize
  */
 function annotateCheck($type, $filename, $line, $message, $colorize)
 {

--- a/tests/errors/mixed-colors.expect
+++ b/tests/errors/mixed-colors.expect
@@ -1,0 +1,7 @@
+[91m
+::error file=redaxo\src\addons\2factor_auth\boot.php,line=6::Call to static method getInstance() on an unknown class rex_one_time_password.
+[0m[93m
+::warning file=redaxo\src\addons\2factor_auth\boot.php,line=9::Call to static method getInstance() on an unknown class rex_minibar.
+[0m[91m
+::error file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.
+[0m

--- a/tests/errors/mixed.expect
+++ b/tests/errors/mixed.expect
@@ -1,0 +1,3 @@
+::error file=redaxo\src\addons\2factor_auth\boot.php,line=6::Call to static method getInstance() on an unknown class rex_one_time_password.
+::warning file=redaxo\src\addons\2factor_auth\boot.php,line=9::Call to static method getInstance() on an unknown class rex_minibar.
+::error file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.

--- a/tests/errors/mixed.xml
+++ b/tests/errors/mixed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+    <file name="redaxo\src\addons\2factor_auth\boot.php">
+        <error line="6" column="1" severity="error" message="Call to static method getInstance() on an unknown class rex_one_time_password." />
+        <error line="9" column="1" severity="warning" message="Call to static method getInstance() on an unknown class rex_minibar." />
+    </file>
+    <file name="redaxo\src\addons\2factor_auth\lib\one_time_password.php">
+        <error line="0" column="1" severity="error" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
+    </file>
+</checkstyle>

--- a/tests/errors/mixed.xml
+++ b/tests/errors/mixed.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
     <file name="redaxo\src\addons\2factor_auth\boot.php">
-        <error line="6" column="1" severity="error" message="Call to static method getInstance() on an unknown class rex_one_time_password." />
+        <error line="6" column="1" severity="failure" message="Call to static method getInstance() on an unknown class rex_one_time_password." />
         <error line="9" column="1" severity="warning" message="Call to static method getInstance() on an unknown class rex_minibar." />
     </file>
     <file name="redaxo\src\addons\2factor_auth\lib\one_time_password.php">
-        <error line="0" column="1" severity="error" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
+        <error line="0" column="1" severity="failure" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
     </file>
 </checkstyle>

--- a/tests/errors/warning-only.expect
+++ b/tests/errors/warning-only.expect
@@ -1,0 +1,3 @@
+::warning file=redaxo/src/addons/2factor_auth/boot.php,line=6::Call to static method getInstance() on an unknown class rex_one_time_password.
+::warning file=redaxo/src/addons/2factor_auth/boot.php,line=9::Call to static method getInstance() on an unknown class rex_minibar.
+::warning file=redaxo/src/addons/2factor_auth/lib/one_time_password.php,line=0::Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.

--- a/tests/errors/warning-only.xml
+++ b/tests/errors/warning-only.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+    <file name="redaxo/src/addons/2factor_auth/boot.php">
+        <error line="6" column="1" severity="warning" message="Call to static method getInstance() on an unknown class rex_one_time_password." />
+        <error line="9" column="1" severity="warning" message="Call to static method getInstance() on an unknown class rex_minibar." />
+    </file>
+    <file name="redaxo/src/addons/2factor_auth/lib/one_time_password.php">
+        <error line="0" column="1" severity="warning" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
+    </file>
+</checkstyle>

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -11,9 +11,9 @@
  * https://github.com/staabm/annotate-pull-request-from-checkstyle
  */
 
-function testXml($xmlPath, $expectedExit, $expectedOutput = null)
+function testXml($xmlPath, $expectedExit, $expectedOutput = null, $options = '')
 {
-    exec('cat '.$xmlPath .' | php '. __DIR__ .'/../cs2pr 2>&1', $output, $exit);
+    exec('cat '.$xmlPath .' | php '. __DIR__ .'/../cs2pr '.$options.' 2>&1', $output, $exit);
     $output = implode("\n", $output);
 
     if ($exit != $expectedExit) {
@@ -42,6 +42,14 @@ testXml(__DIR__.'/fail/invalid.xml', 2, "Error: Start tag expected, '<' not foun
 testXml(__DIR__.'/fail/multiple-suites.xml', 2, "Error: Extra content at the end of the document on line 8, column 1\n\n" .file_get_contents(__DIR__.'/fail/multiple-suites.xml'));
 
 testXml(__DIR__.'/errors/minimal.xml', 1, file_get_contents(__DIR__.'/errors/minimal.expect'));
+testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed.expect'));
+testXml(__DIR__.'/errors/warning-only.xml', 1, file_get_contents(__DIR__.'/errors/warning-only.expect'));
+
+testXml(__DIR__.'/errors/minimal.xml', 1, file_get_contents(__DIR__.'/errors/minimal.expect'), '--graceful-warnings');
+testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed.expect'), '--graceful-warnings');
+testXml(__DIR__.'/errors/warning-only.xml', 0, file_get_contents(__DIR__.'/errors/warning-only.expect'), '--graceful-warnings');
+
+testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed-colors.expect'), '--colorize');
 
 testXml(__DIR__.'/noerrors/only-header.xml', 0, file_get_contents(__DIR__.'/noerrors/only-header.expect'));
 testXml(__DIR__.'/noerrors/only-header-php-cs-fixer.xml', 0, file_get_contents(__DIR__.'/noerrors/only-header-php-cs-fixer.expect'));


### PR DESCRIPTION
- [x] scan `$argv` for options
- [x] new option `--graceful-warnings`: Don't exit with error codes if there are only warnings (fixes #13)
- [x] new option `--colorize`: Colorize the output. Useful if the same lint script should be used locally on the command line and remote on Github Actions. With this option, errors and warnings are better distinguishable on the command line and the output is still compatible with Github Annotations (see screenshot below).

![Screenshot](https://user-images.githubusercontent.com/6277619/74605450-96afb400-50c8-11ea-9e02-d8cbeb7548ab.png)
