### PR TITLE
Use quiet mode for phpcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ php-cs-fixer --format=checkstyle | vendor/bin/cs2pr
 ### Using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
 
 ```bash
-phpcs --report=checkstyle /path/to/code | vendor/bin/cs2pr
+phpcs --report=checkstyle -q /path/to/code | vendor/bin/cs2pr
 ```
 
 ## phpunit support?


### PR DESCRIPTION
phpcs wrongly outputs the progress bar and timing information on stdout.
This will change in v4, see https://github.com/squizlabs/PHP_CodeSniffer/commit/d4f33dbf45aa5bb78e077b0e73306746c8bd98cf