### PR TITLE
Fix php-cs-fixer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ psalm --output-format=github
 ### Using [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)
 
 ```bash
-php-cs-fixer --format=checkstyle | vendor/bin/cs2pr
+php-cs-fixer fix --dry-run --format=checkstyle | vendor/bin/cs2pr
 ```
 
 ### Using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)


### PR DESCRIPTION
I'll be honest, I'm not 100% sure about that, but that's the only way I could make it work.

Indeed, `php-cs-fixer` is a Symfony app and require a command (`fix` here).

I used the `--dry-run` option because changes are reported to the PR anyway, so might as well not change the code on disk.