### PR TITLE
Composer: Allow lowest php version: 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "staabm/annotate-pull-request-from-checkstyle",
   "license" : "MIT",
   "require" : {
-    "php"          : "^7.0 || ^8.0",
+    "php"          : "^5.3 || ^7.0 || ^8.0",
     "ext-simplexml" : "*"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "license" : "MIT",
   "require" : {
     "php"          : "^5.3 || ^7.0 || ^8.0",
+    "ext-libxml" : "*",
     "ext-simplexml" : "*"
   },
   "require-dev" : {

--- a/cs2pr
+++ b/cs2pr
@@ -23,7 +23,7 @@ $colorize = false;
 $gracefulWarnings = false;
 
 // parameters
-$params = [];
+$params = array();
 foreach ($argv as $arg) {
     if (substr($arg, 0, 2) === '--') {
         $option = substr($arg, 2);
@@ -127,10 +127,10 @@ function relativePath($path)
 
 function annotateType($type)
 {
-    if (in_array($type, ['error', 'failure'])) {
+    if (in_array($type, array('error', 'failure'))) {
         return 'error';
     }
-    if (in_array($type, ['info', 'notice'])) {
+    if (in_array($type, array('info', 'notice'))) {
         return 'notice';
     }
     return 'warning';

--- a/cs2pr
+++ b/cs2pr
@@ -73,7 +73,7 @@ if ($root === false) {
         fwrite(STDERR, 'Error: Unknown error. Expecting checkstyle formatted xml input.' ."\n\n");
     }
     fwrite(STDERR, $xml);
-    
+
     exit(2);
 }
 
@@ -110,7 +110,7 @@ function annotateCheck($type, $filename, $line, $message, $colorize)
     // newlines need to be encoded
     // see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448
     $message = str_replace("\n", '%0A', $message);
-    
+
     if ($colorize) {
         echo "\033[".($type==='error' ? '91' : '93')."m\n";
     }


### PR DESCRIPTION
The code does not use (much) features from newer php versions.
But this tool is really useful for projects that support old versions, and want to use this tool.

Such use will be at their own risk, as this project doesn't CI test those versions.

example:
- https://github.com/zf1s/zf1