### PR TITLE
GithubActions: don't run csfix action on forks

### DIFF
--- a/.github/workflows/csfix.yml
+++ b/.github/workflows/csfix.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
-    if: github.repository.name == "staabm/annotate-pull-request-from-checkstyle"
+    # dont run on forks. requires commit access
+    if: github.event.pull_request.head.repo.full_name == github.repository
     
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/csfix.yml
+++ b/.github/workflows/csfix.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
+    if: github.repository.name == "staabm/annotate-pull-request-from-checkstyle"
+    
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
doesn't work without commit permissions.

as suggested in https://github.com/staabm/annotate-pull-request-from-checkstyle/pull/65#issuecomment-798137491