### PR TITLE
Adds `notices-as-warnings` option

### DIFF
--- a/cs2pr
+++ b/cs2pr
@@ -21,6 +21,7 @@ $version = '1.5.1-dev';
 // options
 $colorize = false;
 $gracefulWarnings = false;
+$noticeAsWarning = false;
 
 // parameters
 $params = array();
@@ -33,6 +34,9 @@ foreach ($argv as $arg) {
             break;
         case 'colorize':
             $colorize = true;
+            break;
+        case 'notices-as-warnings':
+            $noticeAsWarning = true;
             break;
         default:
             echo "Unknown option ".$option."\n";
@@ -55,6 +59,7 @@ if (count($params) === 1) {
     echo "Supported options:\n";
     echo "  --graceful-warnings   Don't exit with error codes if there are only warnings.\n";
     echo "  --colorize            Colorize the output (still compatible with Github Annotations)\n";
+    echo "  --notices-as-warnings Convert notices to warnings.\n";
     exit(9);
 }
 
@@ -87,7 +92,7 @@ foreach ($root as $file) {
         $line = (string) $error['line'];
         $message = (string) $error['message'];
 
-        $annotateType = annotateType($type);
+        $annotateType = annotateType($type, $noticeAsWarning);
         annotateCheck($annotateType, relativePath($filename), $line, $message, $colorize);
 
         if (!$gracefulWarnings || $annotateType === 'error') {
@@ -125,12 +130,12 @@ function relativePath($path)
     return str_replace(getcwd().'/', '', $path);
 }
 
-function annotateType($type)
+function annotateType($type, $noticeAsWarning)
 {
     if (in_array($type, array('error', 'failure'))) {
         return 'error';
     }
-    if (in_array($type, array('info', 'notice'))) {
+    if ( !$noticeAsWarning && in_array($type, array('info', 'notice'))) {
         return 'notice';
     }
     return 'warning';

--- a/cs2pr
+++ b/cs2pr
@@ -135,7 +135,7 @@ function annotateType($type, $noticeAsWarning)
     if (in_array($type, array('error', 'failure'))) {
         return 'error';
     }
-    if ( !$noticeAsWarning && in_array($type, array('info', 'notice'))) {
+    if (!$noticeAsWarning && in_array($type, array('info', 'notice'))) {
         return 'notice';
     }
     return 'warning';

--- a/cs2pr
+++ b/cs2pr
@@ -59,7 +59,7 @@ if (count($params) === 1) {
     echo "Supported options:\n";
     echo "  --graceful-warnings   Don't exit with error codes if there are only warnings.\n";
     echo "  --colorize            Colorize the output (still compatible with Github Annotations)\n";
-    echo "  --notices-as-warnings Convert notices to warnings.\n";
+    echo "  --notices-as-warnings Convert notices to warnings (Github does not annotate notices otherwise).\n";
     exit(9);
 }
 

--- a/tests/errors/notices-as-warnings.expect
+++ b/tests/errors/notices-as-warnings.expect
@@ -1,0 +1,3 @@
+::warning file=redaxo\src\addons\2factor_auth\boot.php,line=6::Call to static method getInstance() on an unknown class rex_one_time_password.
+::warning file=redaxo\src\addons\2factor_auth\boot.php,line=9::Call to static method getInstance() on an unknown class rex_minibar.
+::warning file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.

--- a/tests/errors/notices.expect
+++ b/tests/errors/notices.expect
@@ -1,0 +1,3 @@
+::notice file=redaxo\src\addons\2factor_auth\boot.php,line=6::Call to static method getInstance() on an unknown class rex_one_time_password.
+::notice file=redaxo\src\addons\2factor_auth\boot.php,line=9::Call to static method getInstance() on an unknown class rex_minibar.
+::notice file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.

--- a/tests/errors/notices.xml
+++ b/tests/errors/notices.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+    <file name="redaxo\src\addons\2factor_auth\boot.php">
+        <error line="6" column="1" severity="notice" message="Call to static method getInstance() on an unknown class rex_one_time_password." />
+        <error line="9" column="1" severity="notice" message="Call to static method getInstance() on an unknown class rex_minibar." />
+    </file>
+    <file name="redaxo\src\addons\2factor_auth\lib\one_time_password.php">
+        <error line="0" column="1" severity="notice" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
+    </file>
+</checkstyle>

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -49,6 +49,9 @@ testXml(__DIR__.'/errors/minimal.xml', 1, file_get_contents(__DIR__.'/errors/min
 testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed.expect'), '--graceful-warnings');
 testXml(__DIR__.'/errors/warning-only.xml', 0, file_get_contents(__DIR__.'/errors/warning-only.expect'), '--graceful-warnings');
 
+testXml(__DIR__.'/errors/notices.xml', 1, file_get_contents(__DIR__.'/errors/notices.expect'));
+testXml(__DIR__.'/errors/notices.xml', 1, file_get_contents(__DIR__.'/errors/notices-as-warnings.expect'), '--notices-as-warnings');
+
 testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed-colors.expect'), '--colorize');
 
 testXml(__DIR__.'/noerrors/only-header.xml', 0, file_get_contents(__DIR__.'/noerrors/only-header.expect'));


### PR DESCRIPTION
GitHub Actions don't actually have a notice level, so they just get added to the log but not the file tab

![image](https://user-images.githubusercontent.com/133747/117490674-b8e35b00-af34-11eb-97aa-cbef4ff6aff5.png)

This PR just adds a `--no-notices` flag that lets you have them as GitHub warnings.