### PR TITLE
Adds a flag to allow showing the source of the message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "ext-simplexml" : "*"
   },
   "require-dev" : {
-    "friendsofphp/php-cs-fixer": "^2.16.1"
+    "friendsofphp/php-cs-fixer": "^2.16.1",
+    "donatj/drop": "^1.0"
   },
   "authors" : [
     {

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     "ext-simplexml" : "*"
   },
   "require-dev" : {
-    "friendsofphp/php-cs-fixer": "^2.16.1",
-    "donatj/drop": "^1.0"
+    "friendsofphp/php-cs-fixer": "^2.16.1"
   },
   "authors" : [
     {

--- a/cs2pr
+++ b/cs2pr
@@ -22,6 +22,7 @@ $version = '1.5.1-dev';
 $colorize = false;
 $gracefulWarnings = false;
 $noticeAsWarning = false;
+$prependSource = false;
 
 // parameters
 $params = array();
@@ -34,6 +35,9 @@ foreach ($argv as $arg) {
             break;
         case 'colorize':
             $colorize = true;
+            break;
+        case 'prepend-source':
+            $prependSource = true;
             break;
         case 'notices-as-warnings':
             $noticeAsWarning = true;
@@ -60,6 +64,7 @@ if (count($params) === 1) {
     echo "  --graceful-warnings   Don't exit with error codes if there are only warnings.\n";
     echo "  --colorize            Colorize the output (still compatible with Github Annotations)\n";
     echo "  --notices-as-warnings Convert notices to warnings (Github does not annotate notices otherwise).\n";
+    echo "  --prepend-source      Prepend error 'source' attribute to the message.\n";
     exit(9);
 }
 
@@ -91,6 +96,11 @@ foreach ($root as $file) {
         $type = (string) $error['severity'];
         $line = (string) $error['line'];
         $message = (string) $error['message'];
+        $source = isset($error['source']) ? (string) $error['source'] : null;
+
+        if ($prependSource && $source) {
+            $message = $source.': '.$message;
+        }
 
         $annotateType = annotateType($type, $noticeAsWarning);
         annotateCheck($annotateType, relativePath($filename), $line, $message, $colorize);

--- a/tests/errors/mixed-source-attributes.expect
+++ b/tests/errors/mixed-source-attributes.expect
@@ -1,0 +1,7 @@
+::error file=test/phpunit/Traits/BuildingPermissionIdAwareTraitTest.php,line=13::PhanUndeclaredMethod: Call to undeclared method \PHPUnit\Framework\MockObject\MockObject::getPermissionIds
+::warning file=test/phpunit/Utils/Cidr/MultiCidrMatchTest.php,line=12::PhanUndeclaredClassReference: Reference to undeclared class \CIDRmatch\CIDRmatch
+::warning file=test/phpunit/Utils/Cidr/MultiCidrMatchTest.php,line=21::PhanTypeMismatchArgument: Argument 2 ($CIDRmatch) is $cidr of type \PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject but \Utils\Cidr\MultiCidrMatch::__construct() takes \CIDRmatch\CIDRmatch defined at application/classes/Utils/Cidr/MultiCidrMatch.php:20
+::warning file=test/phpunit/Utils/Cidr/MultiCidrMatchTest.php,line=28::PhanUndeclaredClassReference: Reference to undeclared class \CIDRmatch\CIDRmatch
+::warning file=test/phpunit/Utils/Cidr/MultiCidrMatchTest.php,line=38::PhanTypeMismatchArgument: Argument 2 ($CIDRmatch) is $cidr of type \PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject but \Utils\Cidr\MultiCidrMatch::__construct() takes \CIDRmatch\CIDRmatch defined at application/classes/Utils/Cidr/MultiCidrMatch.php:20
+::error file=test/phpunit/Utils/Cidr/MultiCidrMatchTest.php,line=54::Call to undeclared method \PHPUnit\Framework\MockObject\MockObject::matchAny
+::error file=test/phpunit/Utils/Cidr/MultiCidrMatchTest.php,line=69::Call to undeclared method \PHPUnit\Framework\MockObject\MockObject::matchAny

--- a/tests/errors/mixed-source-attributes.xml
+++ b/tests/errors/mixed-source-attributes.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="ISO-8859-15"?>
+<checkstyle version="6.5">
+  <file name="test/phpunit/Traits/BuildingPermissionIdAwareTraitTest.php">
+    <error line="13" severity="error" message="Call to undeclared method \PHPUnit\Framework\MockObject\MockObject::getPermissionIds" source="PhanUndeclaredMethod"/>
+  </file>
+  <file name="test/phpunit/Utils/Cidr/MultiCidrMatchTest.php">
+    <error line="12" severity="warning" message="Reference to undeclared class \CIDRmatch\CIDRmatch" source="PhanUndeclaredClassReference"/>
+    <error line="21" severity="warning" message="Argument 2 ($CIDRmatch) is $cidr of type \PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject but \Utils\Cidr\MultiCidrMatch::__construct() takes \CIDRmatch\CIDRmatch defined at application/classes/Utils/Cidr/MultiCidrMatch.php:20" source="PhanTypeMismatchArgument"/>
+    <error line="28" severity="warning" message="Reference to undeclared class \CIDRmatch\CIDRmatch" source="PhanUndeclaredClassReference"/>
+    <error line="38" severity="warning" message="Argument 2 ($CIDRmatch) is $cidr of type \PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject but \Utils\Cidr\MultiCidrMatch::__construct() takes \CIDRmatch\CIDRmatch defined at application/classes/Utils/Cidr/MultiCidrMatch.php:20" source="PhanTypeMismatchArgument"/>
+    <error line="54" severity="error" message="Call to undeclared method \PHPUnit\Framework\MockObject\MockObject::matchAny"/>
+    <error line="69" severity="error" message="Call to undeclared method \PHPUnit\Framework\MockObject\MockObject::matchAny"/>
+  </file>
+</checkstyle>

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -52,6 +52,8 @@ testXml(__DIR__.'/errors/warning-only.xml', 0, file_get_contents(__DIR__.'/error
 testXml(__DIR__.'/errors/notices.xml', 1, file_get_contents(__DIR__.'/errors/notices.expect'));
 testXml(__DIR__.'/errors/notices.xml', 1, file_get_contents(__DIR__.'/errors/notices-as-warnings.expect'), '--notices-as-warnings');
 
+testXml(__DIR__.'/errors/mixed-source-attributes.xml', 1, file_get_contents(__DIR__.'/errors/mixed-source-attributes.expect'), '--prepend-source');
+
 testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed-colors.expect'), '--colorize');
 
 testXml(__DIR__.'/noerrors/only-header.xml', 0, file_get_contents(__DIR__.'/noerrors/only-header.expect'));


### PR DESCRIPTION
With Phan (and likely others) it's nice to know what specific rule you're breaking. 

This simply adds a flag `--show-source` that prefixes the message with the source attribute of the error line.

```xml
  <file name="application/routes/www/user/user.php">
    <error line="73" severity="info" message="Code $cdnPath has a dynamic format string that could not be inferred by Phan" source="PhanPluginPrintfVariableFormatString"/>
  </file>
```

So this goes from `Code $cdnPath has a dynamic format string that could not be inferred by Phan`

to: `PhanPluginPrintfVariableFormatString: Code $cdnPath has a dynamic format string that could not be inferred by Phan`