### PR TITLE
Add support to prepend the filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cs2pr /path/to/checkstyle-report.xml
 - `--graceful-warnings`: Don't exit with error codes if there are only warnings
 - `--colorize`: Colorize the output. Useful if the same lint script should be used locally on the command line and remote on GitHub Actions. With this option, errors and warnings are better distinguishable on the command line and the output is still compatible with GitHub Annotations
 - `--notices-as-warnings` Converts notices to warnings. This can be useful because GitHub does not annotate notices. 
+- `--prepend-filename` Prepend the filename to the output message
 - `--prepend-source` When the checkstyle generating tool provides a `source` attribute, prepend the source to the output message. 
 
 

--- a/cs2pr
+++ b/cs2pr
@@ -22,6 +22,7 @@ $version = '1.7.2-dev';
 $colorize = false;
 $gracefulWarnings = false;
 $noticeAsWarning = false;
+$prependFilename = false;
 $prependSource = false;
 
 // parameters
@@ -35,6 +36,9 @@ foreach ($argv as $arg) {
             break;
         case 'colorize':
             $colorize = true;
+            break;
+        case 'prepend-filename':
+            $prependFilename = true;
             break;
         case 'prepend-source':
             $prependSource = true;
@@ -64,6 +68,7 @@ if (count($params) === 1) {
     echo "  --graceful-warnings   Don't exit with error codes if there are only warnings.\n";
     echo "  --colorize            Colorize the output (still compatible with Github Annotations)\n";
     echo "  --notices-as-warnings Convert notices to warnings (Github does not annotate notices otherwise).\n";
+    echo "  --prepend-filename    Prepend error 'filename' attribute to the message.\n";
     echo "  --prepend-source      Prepend error 'source' attribute to the message.\n";
     exit(9);
 }
@@ -100,6 +105,10 @@ foreach ($root as $file) {
 
         if ($prependSource && $source) {
             $message = $source.': '.$message;
+        }
+
+        if ($prependFilename && $filename) {
+            $message = $filename.': '.$message;
         }
 
         $annotateType = annotateType($type, $noticeAsWarning);

--- a/cs2pr
+++ b/cs2pr
@@ -108,7 +108,7 @@ foreach ($root as $file) {
         }
 
         if ($prependFilename && $filename) {
-            $message = $filename.': '.$message;
+            $message = filenameOnly($filename).': '.$message;
         }
 
         $annotateType = annotateType($type, $noticeAsWarning);
@@ -188,4 +188,12 @@ function escapeProperty($property)
     $property = str_replace(",", '%2C', $property);
 
     return $property;
+}
+
+/**
+ * Get the filename only from a filepath. Built to work across windows & linux.
+ */
+function filenameOnly($filepath)
+{
+    return basename(str_replace("\\", "/", $filepath));
 }

--- a/tests/errors/prepend-filename.expect
+++ b/tests/errors/prepend-filename.expect
@@ -1,3 +1,4 @@
-::error file=redaxo\src\addons\2factor_auth\boot.php,line=6::redaxo\src\addons\2factor_auth\boot.php: Call to static method getInstance() on an unknown class rex_one_time_password.
-::error file=redaxo\src\addons\2factor_auth\boot.php,line=9::redaxo\src\addons\2factor_auth\boot.php: Call to static method getInstance() on an unknown class rex_minibar.
-::error file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::redaxo\src\addons\2factor_auth\lib\one_time_password.php: Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.
+::error file=redaxo\src\addons\2factor_auth\boot.php,line=6::boot.php: Call to static method getInstance() on an unknown class rex_one_time_password.
+::error file=redaxo\src\addons\2factor_auth\boot.php,line=9::boot.php: Call to static method getInstance() on an unknown class rex_minibar.
+::error file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::one_time_password.php: Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.
+::error file=redaxo/src/addons/2factor_auth/lib/linux_filepath.php,line=0::linux_filepath.php: Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.

--- a/tests/errors/prepend-filename.expect
+++ b/tests/errors/prepend-filename.expect
@@ -1,0 +1,3 @@
+::error file=redaxo\src\addons\2factor_auth\boot.php,line=6::redaxo\src\addons\2factor_auth\boot.php: Call to static method getInstance() on an unknown class rex_one_time_password.
+::error file=redaxo\src\addons\2factor_auth\boot.php,line=9::redaxo\src\addons\2factor_auth\boot.php: Call to static method getInstance() on an unknown class rex_minibar.
+::error file=redaxo\src\addons\2factor_auth\lib\one_time_password.php,line=0::redaxo\src\addons\2factor_auth\lib\one_time_password.php: Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly.

--- a/tests/errors/prepend-filename.xml
+++ b/tests/errors/prepend-filename.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+    <file name="redaxo\src\addons\2factor_auth\boot.php">
+        <error line="6" column="1" severity="error" message="Call to static method getInstance() on an unknown class rex_one_time_password." />
+        <error line="9" column="1" severity="error" message="Call to static method getInstance() on an unknown class rex_minibar." />
+    </file>
+    <file name="redaxo\src\addons\2factor_auth\lib\one_time_password.php">
+        <error line="0" column="1" severity="error" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
+    </file>
+</checkstyle>

--- a/tests/errors/prepend-filename.xml
+++ b/tests/errors/prepend-filename.xml
@@ -7,4 +7,7 @@
     <file name="redaxo\src\addons\2factor_auth\lib\one_time_password.php">
         <error line="0" column="1" severity="error" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
     </file>
+    <file name="redaxo/src/addons/2factor_auth/lib/linux_filepath.php">
+        <error line="0" column="1" severity="error" message="Class rex_one_time_password was not found while trying to analyse it - autoloading is probably not configured properly." />
+    </file>
 </checkstyle>

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -52,6 +52,7 @@ testXml(__DIR__.'/errors/warning-only.xml', 0, file_get_contents(__DIR__.'/error
 testXml(__DIR__.'/errors/notices.xml', 1, file_get_contents(__DIR__.'/errors/notices.expect'));
 testXml(__DIR__.'/errors/notices.xml', 1, file_get_contents(__DIR__.'/errors/notices-as-warnings.expect'), '--notices-as-warnings');
 
+testXml(__DIR__.'/errors/prepend-filename.xml', 1, file_get_contents(__DIR__.'/errors/prepend-filename.expect'), '--prepend-filename');
 testXml(__DIR__.'/errors/mixed-source-attributes.xml', 1, file_get_contents(__DIR__.'/errors/mixed-source-attributes.expect'), '--prepend-source');
 
 testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed-colors.expect'), '--colorize');


### PR DESCRIPTION
When using this annotator, it can be hard to identify what file has caused the issue from the GitHub Actions log output, as we'll get something like this:

```
Warning: Generic.Metrics.CyclomaticComplexity.TooHigh: Function's cyclomatic complexity (15) exceeds 10; consider refactoring the function
Warning: Squiz.PHP.DisallowMultipleAssignments.Found: Assignments must be the first block of code on a line
```

The GitHub UI doesn't easily translate those messages to the filename that is affected, which means that on large PRs it can be a little tricky just looking at this output to see what file has changed. I have to trawl through the files changed to find the relevant output.

We would find it useful/beneficial to be able to see the filename in the GitHub Actions log too.

It doesn't appear that you can get just the message (e.g. https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-a-warning-message says it just prints the "message" - not the file).

Therefore, I've added a `--prepend-filename` arg like the `--prepend-source` to make finding these a little easier. I appreciate it's probably not for everyone (as it'll also put the filename in the message on the annotation) but thought it might be helpful?