### PR TITLE
README: harden the PHPCS code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ To see the output both in the PR as well as in the action logs, use two steps, l
 
 ```yaml
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml
 ```
 


### PR DESCRIPTION
If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow code sample to allow for that situation and still fail the build in that case.