### PR TITLE
DX: Add composer keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Images from https://github.com/mheap/phpunit-github-actions-printer_
 
 Install the binary via composer
 ```bash
-composer require staabm/annotate-pull-request-from-checkstyle
+composer require staabm/annotate-pull-request-from-checkstyle --dev
 ```
 
 ## 💌 Give back some love

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "staabm/annotate-pull-request-from-checkstyle",
   "license" : "MIT",
+  "keywords": ["dev", "continous integration", "github actions"],
   "require" : {
     "php"          : "^5.3 || ^7.0 || ^8.0",
     "ext-libxml" : "*",


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency