### PR TITLE
Makes this usable as a GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ jobs:
                 vendor/bin/phpstan analyse --error-format=checkstyle | vendor/bin/cs2pr
 ```
 
+## Using cs2pr as a GitHub Action
+
+You can also use [`cs2pr` itself as a GitHub Action](https://github.com/staabm/annotate-pull-request-from-checkstyle-action). This is useful if you want to for instance use it for a project that does not use PHP or if you want to use it with a custom PHP installation.
+
+See the example at the [cs2pr GitHub Action repositiory](https://github.com/staabm/annotate-pull-request-from-checkstyle-action#readme).
+
+
+
 # Resources
 
 [GithubAction Problem Matchers](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md)


### PR DESCRIPTION
Fixes #3

I am using this tool for projects that aren't written in PHP, and having to set up PHP in my workflow file is … strange. 

This is the basic framework for setting this up as a GitHub Action.

Here is a test pull request showing it in use

https://github.com/donatj/action-test/pull/1/files

The example warnings are just nonsense to test it, the PHP file has nothing to do with the warnings at hand.

<img width="711" alt="image" src="https://github.com/staabm/annotate-pull-request-from-checkstyle/assets/133747/bf980ab7-2f3a-40e5-8a6d-7c47a52984a3">

I am currently _testing_ a specific hash on that PR,

```
donatj/annotate-pull-request-from-checkstyle@<hash>
```

That would become the following once this is merged and tagged and published in the Market

```
staabm/annotate-pull-request-from-checkstyle@v{insert tag}
```

I am more than happy to answer any questions or make any changes you might request.

