### PR TITLE
Use first line as default when no line is set

### DIFF
--- a/cs2pr
+++ b/cs2pr
@@ -105,7 +105,7 @@ foreach ($root as $file) {
 
     foreach ($file as $error) {
         $type = (string) $error['severity'];
-        $line = (string) $error['line'];
+        $line = (string) (isset($error['line']) ? $error['line'] : 1);
         $message = (string) $error['message'];
         $source = isset($error['source']) ? (string) $error['source'] : null;
 

--- a/tests/errors/without-line.expect
+++ b/tests/errors/without-line.expect
@@ -1,0 +1,3 @@
+::warning file=someFile.php,line=1::Found violation(s) of type: some_fixer_name_here_1
+::warning file=someFile.php,line=1::Found violation(s) of type: some_fixer_name_here_2
+::warning file=anotherFile.php,line=1::Found violation(s) of type: another_fixer_name_here

--- a/tests/errors/without-line.xml
+++ b/tests/errors/without-line.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+    <file name="someFile.php">
+        <error severity="warning" source="PHP-CS-Fixer.some_fixer_name_here_1" message="Found violation(s) of type: some_fixer_name_here_1" />
+        <error severity="warning" source="PHP-CS-Fixer.some_fixer_name_here_2" message="Found violation(s) of type: some_fixer_name_here_2" />
+    </file>
+    <file name="anotherFile.php">
+        <error severity="warning" source="PHP-CS-Fixer.another_fixer_name_here" message="Found violation(s) of type: another_fixer_name_here" />
+    </file>
+</checkstyle>

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -63,3 +63,5 @@ testXml(__DIR__.'/noerrors/only-header-php-cs-fixer.xml', 0, file_get_contents(_
 testXml(__DIR__.'/errors/mixed-case.xml', 1, file_get_contents(__DIR__.'/errors/mixed-case.expect'));
 
 testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/errors-as-warnings.expect'), '--errors-as-warnings');
+
+testXml(__DIR__.'/errors/without-line.xml', 1, file_get_contents(__DIR__.'/errors/without-line.expect'));


### PR DESCRIPTION
Fixes #118

It seems GitHub no longer displays annotations in the [diff view when the line number is zero](https://github.com/orgs/community/discussions/165826).

This PR proposes using the first line as the default when no line is set.