### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ psalm --output-format=github
 php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 ```
 
-### Using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+### Using [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 
 ```bash
 phpcs --report=checkstyle -q /path/to/code | cs2pr


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932