### PR TITLE
README: update schema link for checkstyle reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Continuous Integration](https://github.com/staabm/annotate-pull-request-from-checkstyle/workflows/Continuous%20Integration/badge.svg)](https://github.com/staabm/annotate-pull-request-from-checkstyle/actions)
 [![Continuous Deployment](https://github.com/staabm/annotate-pull-request-from-checkstyle/workflows/Continuous%20Deployment/badge.svg)](https://github.com/staabm/annotate-pull-request-from-checkstyle/actions)
 
-Turns [checkstyle based XML-Reports](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.2/doc/schemas/fix/checkstyle.xsd) into GitHub Pull Request [Annotations via the Checks API](https://docs.github.com/en/free-pro-team@latest/rest/reference/checks).
+Turns [checkstyle based XML-Reports](https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle-report-1.0.0.xsd) into GitHub Pull Request [Annotations via the Checks API](https://docs.github.com/en/free-pro-team@latest/rest/reference/checks).
 This script is meant for use within your GitHub Action.
 
 That means you no longer search thru your GitHub Action logfiles.


### PR DESCRIPTION
Originally, I just wanted to bypass the redirect from `FriendsOfPHP/PHP-CS-Fixer` to `PHP-CS-Fixer/PHP-CS-Fixer`, but then saw that the link could also be updated to the main branch of that repo, and then finally that the version in the main branch is imported from `checkstyle/checkstyle` - so just link there directly.