### PR TITLE
Report processed annotation counts

### DIFF
--- a/cs2pr
+++ b/cs2pr
@@ -99,6 +99,8 @@ if ($root === false) {
 }
 
 $exit = 0;
+$errorCount = 0;
+$warningCount = 0;
 
 foreach ($root as $file) {
     $filename = (string)$file['name'];
@@ -120,11 +122,19 @@ foreach ($root as $file) {
         $annotateType = annotateType($type, $noticeAsWarning, $errorsAsWarnings);
         annotateCheck($annotateType, relativePath($filename), $line, $message, $colorize);
 
+        if ($annotateType === 'error') {
+            ++$errorCount;
+        } elseif ($annotateType === 'warning') {
+            ++$warningCount;
+        }
+
         if (!$gracefulWarnings || $annotateType === 'error') {
             $exit = 1;
         }
     }
 }
+
+fwrite(STDERR, "Processed errors: $errorCount; warnings: $warningCount.\n");
 
 exit($exit);
 

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -11,16 +11,24 @@
  * https://github.com/staabm/annotate-pull-request-from-checkstyle
  */
 
-function testXml($xmlPath, $expectedExit, $expectedOutput = null, $options = '')
+function testXml($xmlPath, $expectedExit, $expectedOutput = null, $options = '', $expectedError = null)
 {
-    exec('cat '.$xmlPath .' | php '. __DIR__ .'/../cs2pr '.$options.' 2>&1', $output, $exit);
+    $errorFile = tempnam(sys_get_temp_dir(), 'cs2pr');
+    exec('cat '.$xmlPath .' | php '. __DIR__ .'/../cs2pr '.$options.' 2>'.$errorFile, $output, $exit);
     $output = implode("\n", $output);
+    $errorOutput = file_get_contents($errorFile);
+    unlink($errorFile);
+
+    if ($expectedError === null) {
+        $expectedError = 'Processed errors: '.substr_count($expectedOutput, '::error ')
+            .'; warnings: '.substr_count($expectedOutput, '::warning ').".\n";
+    }
 
     if ($exit != $expectedExit) {
         var_dump($output);
 
         throw new Exception('Test with ' . $xmlPath . ' failed, expected exit-code ' . $expectedExit . ' got ' . $exit);
-    } elseif ($expectedOutput && $expectedOutput != $output) {
+    } elseif ($expectedOutput !== null && $expectedOutput != $output) {
         echo "EXPECTED:\n";
         var_dump($expectedOutput);
         echo "\n";
@@ -30,16 +38,26 @@ function testXml($xmlPath, $expectedExit, $expectedOutput = null, $options = '')
         echo "\n";
 
         throw new Exception('Test with ' . $xmlPath . ' failed, output mismatch');
+    } elseif ($expectedError != $errorOutput) {
+        echo "EXPECTED STDERR:\n";
+        var_dump($expectedError);
+        echo "\n";
+
+        echo "GOT STDERR:\n";
+        var_dump($errorOutput);
+        echo "\n";
+
+        throw new Exception('Test with ' . $xmlPath . ' failed, stderr mismatch');
     } else {
         echo "success: $xmlPath\n\n";
     }
 }
 
 
-testXml(__DIR__.'/fail/empty.xml', 2, "Error: Expecting xml stream starting with a xml opening tag.\n");
-testXml(__DIR__.'/fail/invalid.xml', 2, "Error: Start tag expected, '<' not found on line 1, column 1\n\n" .file_get_contents(__DIR__.'/fail/invalid.xml'));
+testXml(__DIR__.'/fail/empty.xml', 2, '', '', "Error: Expecting xml stream starting with a xml opening tag.\n\n");
+testXml(__DIR__.'/fail/invalid.xml', 2, '', '', "Error: Start tag expected, '<' not found on line 1, column 1\n\n" .file_get_contents(__DIR__.'/fail/invalid.xml'));
 
-testXml(__DIR__.'/fail/multiple-suites.xml', 2, "Error: Extra content at the end of the document on line 8, column 1\n\n" .file_get_contents(__DIR__.'/fail/multiple-suites.xml'));
+testXml(__DIR__.'/fail/multiple-suites.xml', 2, '', '', "Error: Extra content at the end of the document on line 8, column 1\n\n" .file_get_contents(__DIR__.'/fail/multiple-suites.xml'));
 
 testXml(__DIR__.'/errors/minimal.xml', 1, file_get_contents(__DIR__.'/errors/minimal.expect'));
 testXml(__DIR__.'/errors/mixed.xml', 1, file_get_contents(__DIR__.'/errors/mixed.expect'));


### PR DESCRIPTION
## Summary

- count emitted error and warning annotations
- report the final counts to STDERR after processing completes
- keep GitHub annotation output on STDOUT unchanged
- update the test harness to assert STDOUT and STDERR independently

## Why

An empty STDOUT could mean either that a report contained no errors or warnings, or that processing produced no visible result. A final STDERR status makes successful processing explicit without changing the annotation stream consumed by GitHub Actions.

Closes #28.

## Validation

- all 19 existing report and option scenarios pass
- mixed report keeps the same three STDOUT annotations
- mixed report writes `Processed errors: 2; warnings: 1.` to STDERR
- empty reports write zero error and warning counts
- malformed XML retains its existing STDERR diagnostics
- PHP syntax checks for `cs2pr` and `tests/tests.php`
- Composer manifest validation
- repository PHP CS Fixer dry-run
- Git diff check
